### PR TITLE
Log message when browse view exceeds max_items

### DIFF
--- a/plugins/EPrints/Plugin/ULCCViews.pm
+++ b/plugins/EPrints/Plugin/ULCCViews.pm
@@ -209,7 +209,11 @@ sub update_view_list
 	# hit the limit
 	if( $max_items && $count > $max_items )
 	{
-		$repo->log( "Browse view $view->{id} ($target) contains more than $max_items and has not been rendered.");
+		$repo->log(
+			"Browse view $view->{id} ($target) contains more than $max_items items and has not been rendered.\n" .
+			"Consider creating sub-groupings for this view, increasing the 'max_items' value for this view, " .
+			"or setting a 'browse_views_max_items' setting for the repository."
+		);
 
 		my $PAGE = $xml->create_element( "div",
 			class => "ep_view_page ep_view_page_view_$view->{id}"

--- a/plugins/EPrints/Plugin/ULCCViews.pm
+++ b/plugins/EPrints/Plugin/ULCCViews.pm
@@ -209,6 +209,8 @@ sub update_view_list
 	# hit the limit
 	if( $max_items && $count > $max_items )
 	{
+		$repo->log( "Browse view $view->{id} ($target) contains more than $max_items and has not been rendered.");
+
 		my $PAGE = $xml->create_element( "div",
 			class => "ep_view_page ep_view_page_view_$view->{id}"
 		);


### PR DESCRIPTION
Currently if a browse view exceeds the max_items threshold, it is invisible to a repository administrator, and probably discovered by a user of the repository (who may or may not report it).

This logs instances where a list has not been rendered and suggests how to resolve it.